### PR TITLE
don't use encrypted databags

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,8 @@ maintainer_email 'mveitas@gmail.com'
 license          'Apache 2.0'
 description      'Configures rsyslog to send logs to Loggly'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.1.0'
+version          '2.1.1'
 
 supports 'ubuntu', '>= 12.04'
 
 depends "rsyslog", "~> 1.5.0"
-

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,7 +11,7 @@ if node['loggly']['token']['from_databag']
   databag = node['loggly']['token']['databag']
   databag_item = node['loggly']['token']['databag_item']
 
-  loggly_token = Chef::EncryptedDataBagItem.load(databag, databag_item)['token']
+  loggly_token = data_bag_item('configs', 'loggly')
   raise "No token was found in databag item: #{databag}/#{databag_item}" if loggly_token.nil?
 else
   raise "When not using a Data Bag, you have to define the Loggly token manually" if node['loggly']['token']['value'].empty?

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,7 +11,7 @@ if node['loggly']['token']['from_databag']
   databag = node['loggly']['token']['databag']
   databag_item = node['loggly']['token']['databag_item']
 
-  loggly_token = data_bag_item('configs', 'loggly')
+  loggly_token = data_bag_item('configs', 'loggly')['token']
   raise "No token was found in databag item: #{databag}/#{databag_item}" if loggly_token.nil?
 else
   raise "When not using a Data Bag, you have to define the Loggly token manually" if node['loggly']['token']['value'].empty?


### PR DESCRIPTION
Don't use encrypted databags.

Sure it's less safe but we'll worry about that later.

Also this will break the chef test, again a later issue.

cc @amdtech 
